### PR TITLE
attempt to fix custom github domain overwriting on publish

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.journalovi.org

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,10 +1,12 @@
 project:
-  type: site
+  type: website
   resources:
     - "images/*.svg"
+    - "CNAME"
 
-site:
+website:
   title: "JoVI"
+  site-url: https://journalovi.org
   image: images/jovi_wordmark.svg
   favicon: images/jovi_logo.svg
   navbar:


### PR DESCRIPTION
Turns out the custom domain resetting every publish is a result of how Github handles pages with custom domains. This is an attempt to fix (see https://github.com/quarto-dev/quarto-cli/discussions/3249). ~~I will merge without review since this doesn't change page content, I just need to debug this stupid domain stuff...~~