### PR TITLE
Add github links

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,6 +17,13 @@ website:
     logo-alt: JoVI
     type: dark
     tools:
+      - icon: twitter
+        href: https://twitter.com/journalOVI/
+        text: JoVI Twitter
+      - icon: mastodon
+        href: https://hci.social/@jovi
+        text: JoVI Mastodon
+        rel: me
       - icon: github
         href: https://github.com/journalovi/journalovi.github.io
         text: JoVI Github
@@ -32,6 +39,20 @@ website:
         text: Organizers
       - href: news.qmd
         text: News
+
+  page-footer:
+    left: |
+      Licensed under [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/)
+    right:
+      - icon: twitter
+        href: https://twitter.com/journalOVI/
+        aria-label: JoVI Twitter
+      - icon: mastodon
+        href: https://hci.social/@jovi
+        aria-label: JoVI Mastodon
+      - icon: github
+        href: https://github.com/journalovi/journalovi.github.io
+        aria-label: JoVI Github
 
   sidebar:
     - id: submit

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,11 +9,17 @@ website:
   site-url: https://journalovi.org
   image: images/jovi_wordmark.svg
   favicon: images/jovi_logo.svg
+  repo-url: https://github.com/journalovi/journalovi.github.io
+  repo-actions: [edit, issue]
   navbar:
     title: false
     logo: images/jovi_wordmark.svg
     logo-alt: JoVI
     type: dark
+    tools:
+      - icon: github
+        href: https://github.com/journalovi/journalovi.github.io
+        text: JoVI Github
     left:
       - href: index.qmd
         text: About


### PR DESCRIPTION
This PR:

- adds github, twitter, and mastodon links to each page, like this:
   <img src="https://github.com/journalovi/journalovi.github.io/assets/6345019/d83d2a70-9e90-4116-b51d-a65d2fedbf80" width="50%">

- adds a footer with license and the links again:
   ![image](https://github.com/journalovi/journalovi.github.io/assets/6345019/7e83a5a0-4fc5-4eca-85f8-11a6160e88e5)

- closes #28 
- as a side effect, this should "verify" our mastodon account by setting rel="me" on the mastodon link


