### PR TITLE
Replace link to author guidelines

### DIFF
--- a/reviewer-guide.qmd
+++ b/reviewer-guide.qmd
@@ -142,7 +142,7 @@ JoVI aims to advance knowledge. If the work is promising but still has not made 
 Before sending out to external reviewers:
 
 -   **Desk reject:** The editor-in-chief may choose to desk-reject manuscripts that are clearly outside the scope of the journal, or not written in English. We may set more specific desk rejection criteria in the future; for feedback and discussion on this see [issue #17](https://github.com/journalovi/journalovi.github.io/issues/17).
--   **Pre-review revision:** If a manuscript misses the required components described in [the author guidelines](https://docs.google.com/document/d/1dp4P7kC6p9Lidz9ZlzbUegGqHsdP7gb7Q_nBwLQ2Q24/edit#heading=h.feb0af44qy6), or if the associate editor has other concerns (such as length not being commensurate with contribution), the editor may request the authors to make some revisions prior to sending the manuscript out to reviewers.
+-   **Pre-review revision:** If a manuscript misses the required components described in [the author guidelines](author-guide.qmd), or if the associate editor has other concerns (such as length not being commensurate with contribution), the editor may request the authors to make some revisions prior to sending the manuscript out to reviewers.
 
 After each round of review:
 


### PR DESCRIPTION
Replace the Google Doc link to author guidelines to the actual page on JoVI website