### PR TITLE
Adding processing and reviewing schedule to submit.qmd

### DIFF
--- a/submit.qmd
+++ b/submit.qmd
@@ -56,3 +56,13 @@ To submit to the experimental track, write your paper in [this template](https:/
 ### Reviewing
 
 All review on the experimental track will proceed as Github issues and pull requests, and published papers on this track can be updated using pull requests, even after publication. The Github repository for each submission will be public throughout the process, regardless of the final decision on the submission. Therefore, while withdrawal of a submission is possible (in the sense that authors can ask for their paper not to be considered "published" at JoVI), the submitted paper and reviews will still be public even if the submission is withdrawn or is not accepted.
+
+
+## Schedule
+
+* JoVI organizers will process articles in batches with the cut-off date at __the end of Friday (AoE)__ of each month __except March and September__.
+* Associate editor assignment usually takes two weeks.
+* Reviewer invitation usually takes two weeks.
+* After accepting the invitation, each reviewer has four weeks to write the review.
+* After all reviews arrive, the associate editor may take two weeks to write their meta-review.
+* The reviewing process usually has more than one round.


### PR DESCRIPTION
Implementing the "editor-wrangler" we discussed today + making some other aspects of the reviewing schedule public